### PR TITLE
针对32位以下CPU做的修改及其他

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@
 |:--:|:----:|:--:|:--:|:--:|:--:|
 |[W25Q40BV](http://microchip.ua/esp8266/W25Q40BV(EOL).pdf)|Winbond|4Mb|50Mhz|不支持|已停产|
 |[W25Q80DV](http://www.winbond.com/resource-files/w25q80dv_revg_07212015.pdf)|Winbond|8Mb|104Mhz|支持||
+|[W25Q16BV](https://media.digikey.com/pdf/Data%20Sheets/Winbond%20PDFs/W25Q16BV.pdf)|Winbond|16Mb|104Mhz|不支持||
 |[W25Q16CV](http://www.winbond.com/resource-files/da00-w25q16cvf1.pdf)|Winbond|16Mb|104Mhz|支持||
+|[W25Q16DV](http://www.winbond.com/resource-files/w25q16dv%20revk%2005232016%20doc.pdf)|Winbond|16Mb|104Mhz|支持||
 |[W25Q32BV](http://www.winbond.com/resource-files/w25q32bv_revi_100413_wo_automotive.pdf)|Winbond|32Mb|104Mhz|支持||
 |[W25Q64CV](http://www.winbond.com/resource-files/w25q64cv_revh_052214[2].pdf)|Winbond|64Mb|80Mhz|支持||
 |[W25Q128BV](http://www.winbond.com/resource-files/w25q128bv_revh_100313_wo_automotive.pdf)|Winbond|128Mb|104Mhz|支持||

--- a/sfud/src/sfud_sfdp.c
+++ b/sfud/src/sfud_sfdp.c
@@ -159,7 +159,7 @@ static bool read_basic_header(const sfud_flash *flash, sfdp_para_header *basic_h
     basic_header->minor_rev = header[1];
     basic_header->major_rev = header[2];
     basic_header->len       = header[3];
-    basic_header->ptp       = header[4] | header[5] << 8 | header[6] << 16;
+    basic_header->ptp       = (long)header[4] | (long)header[5] << 8 | (long)header[6] << 16;
     /* check JEDEC basic flash parameter header */
     if (basic_header->major_rev > SUPPORT_MAX_SFDP_MAJOR_REV) {
         SFUD_INFO("Error: This reversion(V%d.%d) JEDEC basic flash parameter header is not supported.",
@@ -171,7 +171,7 @@ static bool read_basic_header(const sfud_flash *flash, sfdp_para_header *basic_h
         return false;
     }
     SFUD_DEBUG("Check JEDEC basic flash parameter header is OK. The table id is %d, reversion is V%d.%d,"
-            " length is %d, parameter table pointer is 0x%06X.", basic_header->id, basic_header->major_rev,
+            " length is %d, parameter table pointer is 0x%06lX.", basic_header->id, basic_header->major_rev,
             basic_header->minor_rev, basic_header->len, basic_header->ptp);
 
     return true;

--- a/sfud/src/sfud_sfdp.c
+++ b/sfud/src/sfud_sfdp.c
@@ -287,7 +287,7 @@ static bool read_basic_table(sfud_flash *flash, sfdp_para_header *basic_header) 
         return false;
     }
     /* get flash memory capacity */
-    uint32_t table2_temp = (table[7] << 24) | (table[6] << 16) | (table[5] << 8) | table[4];
+    uint32_t table2_temp = ((long)table[7] << 24) | ((long)table[6] << 16) | ((long)table[5] << 8) | (long)table[4];
     switch ((table[7] & (0x01 << 7)) >> 7) {
     case 0:
         sfdp->capacity = 1 + (table2_temp >> 3);


### PR DESCRIPTION
1、【更新】针对32位以下CPU做的修改。
2、【更新】添加两款Flash芯片的说明。

@armink 经过测试，下述代码确实也需要修改。

> /* get flash memory capacity */
> uint32_t table2_temp = (table[7] << 24) | (table[6] << 16) | (table[5] << 8) | table[4];

下面是Debug时打印出来的信息。
```
JEDEC basic flash parameter table info:
MSB-LSB  3    2    1    0
[0001] 0xFF 0xF1 0x20 0xE5
[0002] 0x00 0xFF 0xFF 0xFF
```
不做强制转换得到的结果：0xFFFFFFFF
做了转换以后正确的结果：0x00FFFFFF