### PR TITLE
add NM25Q128EV

### DIFF
--- a/sfud/inc/sfud_flash_def.h
+++ b/sfud/inc/sfud_flash_def.h
@@ -91,6 +91,7 @@ typedef struct {
 #define SFUD_MF_ID_GIGADEVICE                          0xC8
 #define SFUD_MF_ID_ISSI                                0xD5
 #define SFUD_MF_ID_WINBOND                             0xEF
+#define SFUD_MF_ID_NOR_MEM                             0x52
 
 /* SFUD supported manufacturer information table */
 #define SFUD_MF_TABLE                                     \

--- a/sfud/inc/sfud_flash_def.h
+++ b/sfud/inc/sfud_flash_def.h
@@ -111,6 +111,7 @@ typedef struct {
     {"ISSI",       SFUD_MF_ID_ISSI},                      \
     {"Winbond",    SFUD_MF_ID_WINBOND},                   \
     {"Micronix",   SFUD_MF_ID_MICRONIX},                  \
+    {"Nor-Mem",    SFUD_MF_ID_NOR_MEM},                   \
 }
 
 #ifdef SFUD_USING_FLASH_INFO_TABLE
@@ -143,6 +144,7 @@ typedef struct {
     {"A25L080", SFUD_MF_ID_AMIC, 0x30, 0x14, 1L*1024L*1024L, SFUD_WM_PAGE_256B, 4096, 0x20},                        \
     {"F25L004", SFUD_MF_ID_ESMT, 0x20, 0x13, 512L*1024L, SFUD_WM_BYTE|SFUD_WM_AAI, 4096, 0x20},                     \
     {"PCT25VF016B", SFUD_MF_ID_SST, 0x25, 0x41, 2L*1024L*1024L, SFUD_WM_BYTE|SFUD_WM_AAI, 4096, 0x20},              \
+    {"NM25Q128EV", SFUD_MF_ID_NOR_MEM, 0x21, 0x18, 16L*1024L*1024L, SFUD_WM_PAGE_256B, 4096, 0x20},                 \
 }
 #endif /* SFUD_USING_FLASH_INFO_TABLE */
 


### PR DESCRIPTION
添加一个诺存微电子（NOR-Mem）的NOR Flash：NM25Q128EV（正点原子的STM32F407 Core Board上板载的Flash，本人没找到数据手册，看正点的例程和华邦一样操作，就照着读出来的ID加了一个型号）