### PR TITLE
Add NOR-Flash support for PUYA

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@
 |[PCT25VF016B](http://pctgroup.com.tw/attachments/files/files/248_25VF016B-P.pdf)|PCT|16Mb|80Mhz|不支持|不支持|SST 授权许可，会被识别为 SST25VF016B|
 |[AT45DB161E](http://www.adestotech.com/wp-content/uploads/doc8782.pdf)|ADESTO|16Mb|85MHz|不支持|不支持|ADESTO 收购 Atmel 串行闪存产品线|
 |[NM25Q128EV](http://www.normem.com/product/278082170)|Nor_Mem|128Mb|未测试|不支持|未测试|SFDP可能会读取到信息后识别为超过32Gb|
+|[P25D40H](https://item.szlcsc.com/583103.html)|PUYA|4Mb|未测试|支持|未测试|by Shan|
+|[P25Q80H](https://item.szlcsc.com/8512446.html)|PUYA|8Mb|未测试|支持|未测试|by Shan|
 
 > 注：QSPI 模式中，双线表示支持双线快读，四线表示支持四线快读。
 >

--- a/sfud/inc/sfud_flash_def.h
+++ b/sfud/inc/sfud_flash_def.h
@@ -92,6 +92,7 @@ typedef struct {
 #define SFUD_MF_ID_GIGADEVICE                          0xC8
 #define SFUD_MF_ID_ISSI                                0xD5
 #define SFUD_MF_ID_WINBOND                             0xEF
+#define SFUD_MF_ID_PUYA                                0x85
 
 /* SFUD supported manufacturer information table */
 #define SFUD_MF_TABLE                                     \
@@ -112,7 +113,8 @@ typedef struct {
     {"ISSI",       SFUD_MF_ID_ISSI},                      \
     {"Winbond",    SFUD_MF_ID_WINBOND},                   \
     {"Macronix",   SFUD_MF_ID_MACRONIX},                  \
-    {"NOR-MEM",    SFUD_MF_ID_NOR_MEM},                        \
+    {"NOR-MEM",    SFUD_MF_ID_NOR_MEM},                   \
+    {"PUYA",       SFUD_MF_ID_PUYA},                      \
 }
 
 #ifdef SFUD_USING_FLASH_INFO_TABLE
@@ -147,7 +149,12 @@ typedef struct {
     {"A25L080", SFUD_MF_ID_AMIC, 0x30, 0x14, 1L*1024L*1024L, SFUD_WM_PAGE_256B, 4096, 0x20},                        \
     {"F25L004", SFUD_MF_ID_ESMT, 0x20, 0x13, 512L*1024L, SFUD_WM_BYTE|SFUD_WM_AAI, 4096, 0x20},                     \
     {"PCT25VF016B", SFUD_MF_ID_SST, 0x25, 0x41, 2L*1024L*1024L, SFUD_WM_BYTE|SFUD_WM_AAI, 4096, 0x20},              \
-    {"NM25Q128EVB", SFUD_MF_ID_NOR_MEM, 0x21, 0x18, 16L*1024L*1024L, SFUD_WM_PAGE_256B, 4096, 0x20},                 \
+    {"NM25Q128EVB", SFUD_MF_ID_NOR_MEM, 0x21, 0x18, 16L*1024L*1024L, SFUD_WM_PAGE_256B, 4096, 0x20},                \
+    {"P25D05H", SFUD_MF_ID_PUYA, 0x60, 0x13, 5L*1024L,       SFUD_WM_PAGE_256B, 4096, 0x20},                        \
+    {"P25D10H", SFUD_MF_ID_PUYA, 0x60, 0x12, 1L*1024L*1024L, SFUD_WM_PAGE_256B, 4096, 0x20},                        \
+    {"P25D20H", SFUD_MF_ID_PUYA, 0x60, 0x11, 2L*1024L*1024L, SFUD_WM_PAGE_256B, 4096, 0x20},                        \
+    {"P25D40H", SFUD_MF_ID_PUYA, 0x60, 0x10, 4L*1024L*1024L, SFUD_WM_PAGE_256B, 4096, 0x20},                        \
+    {"P25Q80H", SFUD_MF_ID_PUYA, 0x30, 0x14, 8L*1024L*1024L, SFUD_WM_PAGE_256B, 4096, 0x20},                        \
 }
 #endif /* SFUD_USING_FLASH_INFO_TABLE */
 


### PR DESCRIPTION
P25D40H 和 P25Q80H 已经在项目上验证。
P25D20/10/05 与上述P25D40属于一个系列，就没有验证。
提交我又仔细核对了一下各参数ID没有问题。
参数如下：
![PUYA Serial](https://aliyuntu.oss-cn-hangzhou.aliyuncs.com/img/image-20231110205429148.png)
