### PR TITLE
Add conditional macro to supress warning

### DIFF
--- a/sfud/src/sfud.c
+++ b/sfud/src/sfud.c
@@ -438,10 +438,13 @@ sfud_err sfud_read(const sfud_flash *flash, uint32_t addr, size_t size, uint8_t 
 #endif
             make_address_byte_array(flash, addr, &cmd_data[1]);
             cmd_size = flash->addr_in_4_byte ? 5 : 4;
+#ifdef SFUD_USING_FAST_READ
+            // Only append dummy bytes if using fast read.
             for (i = 0; i < SFUD_READ_DUMMY_BYTE_CNT; i++) {
                 cmd_data[cmd_size] = SFUD_DUMMY_DATA;
                 cmd_size++;
             }
+#endif
             result = spi->wr(spi, cmd_data, cmd_size, data, size);
         }
     }


### PR DESCRIPTION
注意到 #94 中，若不使用快速读，则这段添加dummy byte的代码可能引起编译器告警。故加入条件宏以消除警告。